### PR TITLE
AVA-89: Add address params to props

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,7 @@ const component = ({
 | itemClassName    | string      | no       | `address-autocomplete__suggestions__item`         |
 | hoverClassName   | string      | no       | `address-autocomplete__suggestions__item--active` |
 | raw              | boolean     | no       | false                                             |
+| addressParams    | Record      | no       |                                                   |
 
 ### Prop: container
 

--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,8 @@ const component = ({
 | raw              | boolean     | no       | false                                             |
 | addressParams    | Record      | no       |                                                   |
 
+Address param options can be found [here](https://addressfinder.com.au/docs/widget_docs/)
+
 ### Prop: container
 
 The container where suggestion list will be docked inside. If not provided, the list sits directly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-addressfinder",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "React address lookup component using AddressFinder",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/WidgetInput.tsx
+++ b/src/WidgetInput.tsx
@@ -9,7 +9,7 @@ import React, {
 
 import { AddressFinderWidgetSrc, ContainerPrefix, Country } from './constants';
 import { addressMetaToAddress } from './helpers';
-import { Address, AddressMeta } from './types';
+import { Address, AddressMeta, AddressParams } from './types';
 
 import './widget.css';
 
@@ -25,6 +25,7 @@ interface WidgetInputProps
   itemClassName?: string;
   hoverClassName?: string;
   raw?: boolean;
+  addressParams?: AddressParams;
 }
 
 export type Props = WidgetInputProps;
@@ -40,6 +41,7 @@ const WidgetInput: FC<WidgetInputProps> = ({
   hoverClassName = 'address-autocomplete__suggestions__item--active',
   addressFinderKey,
   raw = false,
+  addressParams = {},
   ...props
 }) => {
   const [scriptLoaded, setScriptLoaded] = useState(false);
@@ -78,7 +80,7 @@ const WidgetInput: FC<WidgetInputProps> = ({
           hover_class: hoverClassName,
           manual_style: true,
           container: container || document.getElementById(`${ContainerPrefix}-${id}`),
-          address_params: {},
+          address_params: addressParams,
           max_results: 5,
         },
       );

--- a/src/example.tsx
+++ b/src/example.tsx
@@ -13,6 +13,7 @@ const AddressFinder = () => (
     placeholder="Street address, suburb, state"
     onSelected={console.log}
     onChange={console.log}
+    addressParams={{ post_box: '0' }}
   />
 );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,3 +20,23 @@ export interface Address {
   country: string;
   city?: string;
 }
+
+export interface AddressParams {
+  // AU address params
+
+  gnaf?: string;
+  au_paf?: string;
+  canonical?: string;
+  state_codes?: string;
+
+  // NZ address params
+
+  delivered?: string;
+  rural?: string;
+  region_codes?: string;
+
+  // common address params
+
+  post_box?: string;
+  max?: number;
+}


### PR DESCRIPTION
This PR adds the address params to the props of the react address finder widget.
This will be useful for passing options available in https://addressfinder.com.au/docs/widget_docs/